### PR TITLE
Fixing Regex vulnerability. Escaping period marker.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
     validates :username, uniqueness: {scope: :strife_id_tag}
     validates :username, length: {minimum:2, maximum:32}
     validates :email, uniqueness: true
-    validates :email, format: {with: /\A[\w+-.]+@[a-z\d-]+(.[a-z\d-]+)*.[a-z]+\z/i, message: "Not well formed email address"}, 
+    validates :email, format: {with: /\A[\w+-\.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i, message: "Not well formed email address"}, 
     length: {maximum:320, too_long: "Must be 320 or fewer in Length"},uniqueness: {case_sensitive: false}
     validates :phone_number, format:{with: /\+\d{1}\d{3}\d{3}\d{4}/, message: "is invalid, please confirm that it is correct."},
     length: {is: 12, message: "is not of 10 digits long" }, uniqueness: true, allow_nil: true


### PR DESCRIPTION
The email validation does not properly escape periods, resulting in email addresses being incorrectly validated. The following example demonstrates that malicious or incorrectly-formatted email address (test.@yahoocom) is no longer allowed as a valid email.
https://rubular.com/r/k6AkrEt478h2LZ

https://github.com/miker704/Strife/blob/f4e078eeaf9f87534fbb9da1fb7f4e0c1b934de2/app/models/user.rb#L39

This pull request escapes the periods inside this regex to ensure that we are testing for string literals. 